### PR TITLE
onboarding(api): deprecate steps/workflow endpoints; project onboardi…

### DIFF
--- a/e2e-service-change.js
+++ b/e2e-service-change.js
@@ -1,0 +1,142 @@
+/*
+ End-to-end verifier for service_change workflow and onboarding sync
+
+ Usage:
+   BASE_URL=http://localhost:3003 TOKEN=ey... node scripts/e2e-service-change.js
+*/
+
+/* eslint-disable no-console */
+
+const BASE_URL = process.env.BASE_URL || 'http://localhost:3003'
+const TOKEN = process.env.TOKEN
+
+if (!TOKEN) {
+  console.error('Missing TOKEN env. Set TOKEN=<JWT>')
+  process.exit(2)
+}
+
+const headers = {
+  'Content-Type': 'application/json',
+  'Authorization': `Bearer ${TOKEN}`
+}
+
+async function http(method, path, body) {
+  const res = await fetch(`${BASE_URL}${path}`, {
+    method,
+    headers,
+    body: body ? JSON.stringify(body) : undefined
+  })
+  let data = null
+  try {
+    data = await res.json()
+  } catch (_) {
+    // ignore
+  }
+  if (!res.ok) {
+    const msg = data?.error?.message || data?.message || res.statusText
+    throw new Error(`${method} ${path} failed: ${res.status} ${msg}`)
+  }
+  return data
+}
+
+async function getWorkflowState(orderId) {
+  return await http('GET', `/orders/${orderId}/workflow-state`)
+}
+
+async function postStatus(orderId, status, reason) {
+  return await http('POST', `/orders/${orderId}/status`, { status, reason })
+}
+
+async function createServiceChangeOrder() {
+  const payload = {
+    customerId: '7308d209-a5be-49a9-8692-26abe87f7c8b',
+    orderType: 'service_change',
+    priority: 'normal',
+    details: { requestedChange: 'Upgrade to 1Gbps', reason: 'Bandwidth increase' }
+  }
+  const created = await http('POST', '/orders', payload)
+  const order = created?.data || created
+  if (!order?.id) throw new Error('Order create returned no id')
+  return order.id
+}
+
+async function getOnboardingByOrder(orderId) {
+  const act = await http('GET', '/onboarding/active')
+  const list = act?.data || []
+  return list.find(x => String(x.order_id || x.orderId) === String(orderId)) || null
+}
+
+async function getOnboardingDetails(onboardingId) {
+  return await http('GET', `/onboarding/${onboardingId}`)
+}
+
+function expectEq(actual, expected, label) {
+  if (actual !== expected) {
+    throw new Error(`${label} mismatch: expected ${expected} but got ${actual}`)
+  }
+}
+
+async function main() {
+  console.log(`[e2e] Using BASE_URL=${BASE_URL}`)
+
+  // 1) Create order
+  const orderId = await createServiceChangeOrder()
+  console.log(`[e2e] Created service_change order: ${orderId}`)
+
+  // Ensure workflow is initialized
+  const s0 = await getWorkflowState(orderId)
+  console.log('[e2e] Initial workflow state:', s0)
+  expectEq(s0?.state, 'created', 'Initial workflow state')
+
+  // Ensure onboarding exists
+  const ob0 = await getOnboardingByOrder(orderId)
+  if (!ob0) throw new Error('Onboarding not found for order after creation')
+  console.log(`[e2e] Onboarding found: ${ob0.id}`)
+
+  // Mapping: service_change -> onboarding current_step
+  const mapServiceChange = {
+    validated: 'initiated',
+    change_scheduled: 'service_configuration',
+    in_progress: 'provisioning_in_flight',
+    changed: 'service_activated',
+    activated: 'service_activated',
+    completed: 'completed'
+  }
+
+  const steps = [
+    { to: 'validated', reason: 'QA passed' },
+    { to: 'change_scheduled', reason: 'Scheduled' },
+    { to: 'in_progress', reason: 'Engineer started' },
+    { to: 'changed', reason: 'Change applied' },
+    { to: 'activated', reason: 'Service re-activated' },
+    { to: 'completed', reason: 'All checks passed' }
+  ]
+
+  for (const step of steps) {
+    console.log(`[e2e] Transition -> ${step.to}`)
+    await postStatus(orderId, step.to, step.reason)
+    const st = await getWorkflowState(orderId)
+    console.log('[e2e] Workflow state after transition:', st)
+    expectEq(st?.state, step.to, 'Workflow state')
+
+    // Verify onboarding current_step sync
+    const ob = await getOnboardingByOrder(orderId)
+    if (!ob) throw new Error('Onboarding vanished from active list')
+    const obDet = await getOnboardingDetails(ob.id)
+    const currentStep = (obDet?.data?.current_step || obDet?.current_step || '').toString()
+    const expectedStep = mapServiceChange[step.to]
+    if (expectedStep) {
+      expectEq(currentStep, expectedStep, 'Onboarding current_step')
+    }
+  }
+
+  console.log('[e2e] All transitions verified successfully for service_change.')
+}
+
+// Node 18+ has fetch globally
+main().catch(err => {
+  console.error('[e2e] FAILED:', err?.message || err)
+  process.exit(1)
+})
+
+

--- a/src/Routes/onboarding.routes.ts
+++ b/src/Routes/onboarding.routes.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import axios from 'axios';
 import { authenticate, authorize } from '../Middleware/authMiddleware.ts';
-import { initiateOnboarding, getCustomerOnboarding, completeOnboardingStep, getTrialCustomers, getOnboardingWorkflowState, getOnboardingWorkflowHistory, getOnboardingMetrics, getOnboardingWorkflowTransitions } from '../Controllers/onboarding.controller.ts';
+import { initiateOnboarding, getCustomerOnboarding, completeOnboardingStep, getTrialCustomers, getOnboardingMetrics } from '../Controllers/onboarding.controller.ts';
 import { NotificationService } from '../services/notification.service.ts';
 
 
@@ -12,9 +12,10 @@ router.use(authenticate);
 router.post('/initiate', authorize(['onboarding:initiate']), initiateOnboarding);
 router.get('/customers/:customerId', authorize(['onboarding:manage']), getCustomerOnboarding);
 router.put('/:onboardingId/step/:stepId/complete', authorize(['onboarding:manage']), completeOnboardingStep);
-router.get('/:onboardingId/workflow/state', authorize(['onboarding:manage']), getOnboardingWorkflowState);
-router.get('/:onboardingId/workflow/history', authorize(['onboarding:manage']), getOnboardingWorkflowHistory);
-router.get('/:onboardingId/workflow/transitions', authorize(['onboarding:manage']), getOnboardingWorkflowTransitions);
+// Deprecated workflow-specific endpoints: states, history, transitions
+router.get('/:onboardingId/workflow/state', authorize(['onboarding:manage']), (req, res) => res.status(410).json({ success: false, error: { message: 'Deprecated: use orders workflow endpoints' } }));
+router.get('/:onboardingId/workflow/history', authorize(['onboarding:manage']), (req, res) => res.status(410).json({ success: false, error: { message: 'Deprecated: use orders workflow endpoints' } }));
+router.get('/:onboardingId/workflow/transitions', authorize(['onboarding:manage']), (req, res) => res.status(410).json({ success: false, error: { message: 'Deprecated: use orders workflow endpoints' } }));
 router.get('/trial-customers', authorize(['onboarding:view_trials']), getTrialCustomers);
 router.get('/metrics', authorize(['onboarding:manage', 'admin:system_monitoring']), getOnboardingMetrics);
 
@@ -30,11 +31,13 @@ router.get('/active', authorize(['onboarding:manage']), async (req, res) => {
       return res.status(resp.status).json(resp.data);
     } catch {}
 
-    // Local fallback: list most recent onboarding records
+    // Local fallback: list most recent active onboarding records (exclude completed/cancelled)
     const r = await db.query(
       `SELECT id, customer_id, order_id, onboarding_type, current_step, completion_percentage, assigned_to, started_at
          FROM customer_onboarding
         WHERE current_step IS NOT NULL
+          AND (completed_at IS NULL)
+          AND LOWER(current_step) NOT IN ('completed','cancelled')
         ORDER BY started_at DESC
         LIMIT 100`
     );
@@ -44,15 +47,96 @@ router.get('/active', authorize(['onboarding:manage']), async (req, res) => {
   }
 });
 
+// Completion metrics: overall and by order_type for a given period
+// Query params: periodDays (default 30)
+router.get('/metrics/completion', authorize(['onboarding:manage']), async (req, res) => {
+  const db = req.app.get('pgPool');
+  try {
+    const periodDays = Math.max(1, Math.min(180, parseInt(String(req.query.periodDays || '30'))));
+    const r = await db.query(
+      `WITH scoped AS (
+         SELECT co.id, co.started_at, co.completed_at, co.completion_percentage, o.order_type
+           FROM customer_onboarding co
+           LEFT JOIN orders o ON o.id = co.order_id
+          WHERE co.started_at >= NOW() - ($1 || ' days')::interval
+        )
+       SELECT
+         'overall' AS bucket,
+         NULL::text AS order_type,
+         COUNT(*) FILTER (WHERE completed_at IS NOT NULL) AS completed_count,
+         COUNT(*) AS total_started,
+         ROUND(
+           CASE WHEN COUNT(*) = 0 THEN 0
+                ELSE 100.0 * COUNT(*) FILTER (WHERE completed_at IS NOT NULL) / COUNT(*) END
+           , 2) AS completion_rate_pct,
+         ROUND(AVG(EXTRACT(EPOCH FROM (completed_at - started_at))) FILTER (WHERE completed_at IS NOT NULL), 2) AS avg_duration_seconds
+       FROM scoped
+       UNION ALL
+       SELECT
+         'by_type' AS bucket,
+         order_type,
+         COUNT(*) FILTER (WHERE completed_at IS NOT NULL) AS completed_count,
+         COUNT(*) AS total_started,
+         ROUND(
+           CASE WHEN COUNT(*) = 0 THEN 0
+                ELSE 100.0 * COUNT(*) FILTER (WHERE completed_at IS NOT NULL) / COUNT(*) END
+           , 2) AS completion_rate_pct,
+         ROUND(AVG(EXTRACT(EPOCH FROM (completed_at - started_at))) FILTER (WHERE completed_at IS NOT NULL), 2) AS avg_duration_seconds
+       FROM scoped
+       GROUP BY order_type
+       ORDER BY bucket DESC, order_type NULLS LAST`
+      , [periodDays]
+    );
+    return res.json({ success: true, data: r.rows, periodDays });
+  } catch (e: any) {
+    return res.status(500).json({ success: false, error: { message: e?.message || 'Failed to compute completion metrics' } });
+  }
+});
+
+// Alternate path to avoid any router collisions in some environments
+router.get('/list/completed', authorize(['onboarding:manage']), async (req, res) => {
+  const db = req.app.get('pgPool');
+  try {
+    const r = await db.query(
+      `SELECT 
+         co.id,
+         co.customer_id,
+         co.order_id,
+         o.order_type,
+         co.current_step,
+         COALESCE(co.completion_percentage, 100) AS completion_percentage,
+         co.started_at,
+         co.completed_at,
+         EXTRACT(EPOCH FROM (co.completed_at - co.started_at))::bigint AS duration_seconds
+       FROM customer_onboarding co
+       LEFT JOIN orders o ON o.id = co.order_id
+       WHERE co.completed_at IS NOT NULL
+       ORDER BY co.completed_at DESC
+       LIMIT 200`
+    );
+    return res.json({ success: true, data: r.rows });
+  } catch (e: any) {
+    return res.status(500).json({ success: false, error: { message: e?.message || 'Failed to fetch completed onboardings' } });
+  }
+});
+
+// Completed onboarding records with completion metrics (place BEFORE dynamic :id routes)
+// (Removed duplicate later definition to avoid route shadowing)
+
 router.get('/:id', authorize(['onboarding:manage']), async (req, res) => {
   const db = req.app.get('pgPool');
   try {
+    const id = String(req.params.id || '').trim();
+    const isUuid = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$/;
+    if (!isUuid.test(id)) {
+      return res.status(404).json({ success: false, error: { message: 'Onboarding not found' } });
+    }
     try {
       const resp = await axios.get(`${base}/api/onboarding/${req.params.id}`, { timeout: 4000 });
       return res.status(resp.status).json(resp.data);
     } catch {}
 
-    const r = await db.query(`SELECT * FROM customer_onboarding WHERE id = $1 LIMIT 1`, [req.params.id]);
+    const r = await db.query(`SELECT * FROM customer_onboarding WHERE id = $1 LIMIT 1`, [id]);
     if (!r.rows[0]) return res.status(404).json({ success: false, error: { message: 'Onboarding not found' } });
     return res.json({ success: true, data: r.rows[0] });
   } catch (e: any) {
@@ -101,129 +185,35 @@ router.put('/:id/step/:stepId', authorize(['onboarding:manage']), async (req, re
   }
 });
 
-router.get('/:id/steps', authorize(['onboarding:manage']), async (req, res) => {
+// Deprecated: steps endpoint (UI mirrors order workflow; keep SLA/assignment in onboarding)
+router.get('/:id/steps', authorize(['onboarding:manage']), async (_req, res) => {
+  return res.status(410).json({ success: false, error: { message: 'Deprecated: onboarding steps are mirrored from order workflow' } });
+});
+
+// Completed onboarding records with completion metrics
+router.get('/completed', authorize(['onboarding:manage']), async (req, res) => {
   const db = req.app.get('pgPool');
   try {
-    // Reconcile onboarding.current_step with linked order status before returning steps
-    try {
-      const ob = await db.query(`SELECT id, current_step, order_id FROM customer_onboarding WHERE id = $1 LIMIT 1`, [req.params.id]);
-      const orderId = ob.rows[0]?.order_id as string | undefined;
-      const currentStep = (ob.rows[0]?.current_step || '') as string;
-      if (orderId) {
-        const ord = await db.query(`SELECT status FROM orders WHERE id = $1 LIMIT 1`, [orderId]);
-        const status = (ord.rows[0]?.status || '') as string;
-        const mapStatusToStep = (s: string): string | null => {
-          switch (s) {
-            case 'validated': return 'initiated';
-            case 'enriched': return 'requirements_confirmed';
-            case 'fno_submitted': return 'provisioning_requested';
-            case 'fno_accepted': return 'provisioning_in_flight';
-            case 'installation_scheduled': return 'installation_scheduled';
-            case 'installed': return 'installation_complete';
-            case 'activated': return 'service_activated';
-            case 'completed': return 'completed';
-            case 'cancelled': return 'cancelled';
-            default: return null;
-          }
-        };
-        const desired = mapStatusToStep(status);
-        if (desired && desired !== currentStep) {
-          const setCompleted = desired === 'completed' || desired === 'cancelled';
-          await db.query(
-            `UPDATE customer_onboarding 
-               SET current_step = $1::text,
-                   completion_percentage = CASE 
-                     WHEN $1::text = 'initiated' THEN 10
-                     WHEN $1::text = 'requirements_confirmed' THEN 20
-                     WHEN $1::text = 'provisioning_requested' THEN 30
-                     WHEN $1::text = 'provisioning_in_flight' THEN 50
-                     WHEN $1::text = 'installation_scheduled' THEN 60
-                     WHEN $1::text = 'installation_complete' THEN 80
-                     WHEN $1::text = 'service_activated' THEN 90
-                     WHEN $1::text IN ('completed','cancelled') THEN 100
-                     ELSE LEAST(100, COALESCE(completion_percentage, 0)) END,
-                   updated_at = NOW(),
-                   completed_at = CASE WHEN $2::boolean THEN NOW() ELSE completed_at END
-             WHERE id = $3::uuid`,
-            [desired, setCompleted, req.params.id]
-          );
-        }
-      }
-    } catch {}
-
-    try {
-      const resp = await axios.get(`${base}/api/onboarding/${req.params.id}/steps`, { timeout: 4000 });
-      // Normalize with local current_step to ensure status accuracy
-      const r = await db.query(`SELECT current_step FROM customer_onboarding WHERE id = $1 LIMIT 1`, [req.params.id]);
-      const rawCurrent = (r.rows[0]?.current_step || 'initiated') as string;
-      const alias: Record<string, string> = {
-        activated: 'service_activated',
-        activation: 'service_activated',
-        install_scheduled: 'installation_scheduled',
-        install_completed: 'installation_completed',
-        rep_contact_scheduled: 'service_setup', // Map old state to new flow
-        // PRD name → UI step aliases
-        initiated: 'welcome_sent',
-        requirements_confirmed: 'service_configuration',
-        provisioning_requested: 'equipment_ordered',
-        provisioning_in_flight: 'equipment_shipped',
-        installation_complete: 'installation_completed'
-      };
-      const current = alias[rawCurrent] || rawCurrent;
-      const items: any[] = Array.isArray((resp.data as any)?.data) ? (resp.data as any).data : (Array.isArray(resp.data) ? resp.data : []);
-      if (items.length > 0) {
-        const orderedIds = items.map(i => i.id);
-        let currentIndex = orderedIds.indexOf(current);
-        if (currentIndex === -1) {
-          currentIndex = orderedIds.findIndex((id: string) => id === current || id.endsWith(current) || current.endsWith(id));
-        }
-        if (currentIndex === -1) currentIndex = 0;
-        const normalized = items.map((s, idx) => ({
-          ...s,
-          status: idx < currentIndex ? 'completed' : idx === currentIndex ? 'in_progress' : 'pending'
-        }));
-        return res.json({ success: true, data: normalized });
-      }
-      return res.status(resp.status).json(resp.data);
-    } catch {}
-
-    // Local fallback: derive steps from current_step using PRD-compliant workflow
-    const r = await db.query(`SELECT current_step FROM customer_onboarding WHERE id = $1 LIMIT 1`, [req.params.id]);
-    const rawCurrent = (r.rows[0]?.current_step || 'initiated') as string;
-    const alias: Record<string, string> = {
-      activated: 'service_activated',
-      activation: 'service_activated',
-      install_scheduled: 'installation_scheduled',
-      install_completed: 'installation_completed',
-      rep_contact_scheduled: 'service_setup' // Map old state to new flow
-    };
-    const current = alias[rawCurrent] || rawCurrent;
-    
-    // PRD-compliant onboarding workflow steps (matches onboarding service)
-    const ordered = [
-      { id: 'initiated', name: 'Onboarding Initiated', description: 'Onboarding process has been started' },
-      { id: 'welcome_sent', name: 'Welcome Email Sent', description: 'Welcome email has been sent to customer' },
-      { id: 'service_setup', name: 'Service Configuration', description: 'Configure service parameters and account setup' },
-      { id: 'equipment_ordered', name: 'Equipment Ordered', description: 'Equipment has been ordered for installation' },
-      { id: 'equipment_shipped', name: 'Equipment Shipped', description: 'Equipment has been shipped to customer' },
-      { id: 'installation_scheduled', name: 'Installation Scheduled', description: 'Installation appointment has been scheduled' },
-      { id: 'installation_completed', name: 'Installation Completed', description: 'Service installation has been completed' },
-      { id: 'service_activated', name: 'Service Activated', description: 'Service has been activated and tested' },
-      { id: 'follow_up', name: 'Follow-up & Support', description: 'Post-activation follow-up and support setup' },
-      { id: 'completed', name: 'Onboarding Completed', description: 'Onboarding process has been completed successfully' },
-    ];
-    let currentIndex = ordered.findIndex(s => s.id === current);
-    if (currentIndex === -1) {
-      currentIndex = ordered.findIndex(s => s.id.endsWith(current) || current.endsWith(s.id));
-    }
-    if (currentIndex === -1) currentIndex = 0;
-    const data = ordered.map((s, idx) => ({
-      ...s,
-      status: idx < currentIndex ? 'completed' : idx === currentIndex ? 'in_progress' : 'pending'
-    }));
-    return res.json({ success: true, data });
+    const r = await db.query(
+      `SELECT 
+         co.id,
+         co.customer_id,
+         co.order_id,
+         o.order_type,
+         co.current_step,
+         COALESCE(co.completion_percentage, 100) AS completion_percentage,
+         co.started_at,
+         co.completed_at,
+         EXTRACT(EPOCH FROM (co.completed_at - co.started_at))::bigint AS duration_seconds
+       FROM customer_onboarding co
+       LEFT JOIN orders o ON o.id = co.order_id
+       WHERE co.completed_at IS NOT NULL
+       ORDER BY co.completed_at DESC
+       LIMIT 200`
+    );
+    return res.json({ success: true, data: r.rows });
   } catch (e: any) {
-    return res.status(500).json({ success: false, error: { message: e?.message || 'Failed to fetch onboarding steps' } });
+    return res.status(500).json({ success: false, error: { message: e?.message || 'Failed to fetch completed onboardings' } });
   }
 });
 

--- a/src/services/configurable-workflow.service.ts
+++ b/src/services/configurable-workflow.service.ts
@@ -71,7 +71,7 @@ export class ConfigurableWorkflowService {
     this.db = db;
   }
 
-  // Ensure PRD default states/transitions exist for known order types (e.g., new_install)
+  // Ensure PRD default states/transitions exist for known order types
   async ensurePrdDefaults(workflowId: string, orderType: string): Promise<void> {
     // Check how many states exist
     const statesResult = await this.db.query(
@@ -80,21 +80,87 @@ export class ConfigurableWorkflowService {
     );
     const existingNames = new Set<string>(statesResult.rows.map((r: any) => r.state_name));
 
-    if (orderType !== 'new_install') return; // only seed known PRD workflow
+    // Define PRD workflows per order type
+    let desiredStates: Array<{ name: string; type: string; index: number; display: string; desc: string }> = [];
+    let transitions: Array<{ from: string; to: string; name: string; isAutomatic: boolean; conditions?: any }> = [];
 
-    const desiredStates: Array<{ name: string; type: string; index: number; display: string; desc: string }> = [
-      { name: 'created', type: 'start', index: 1, display: 'Order Created', desc: 'Order has been created and is ready for processing' },
-      { name: 'validated', type: 'validation', index: 2, display: 'Order Validated', desc: 'Order data has been validated for completeness and accuracy' },
-      { name: 'enriched', type: 'enrichment', index: 3, display: 'Order Enriched', desc: 'Order has been enriched with network-specific parameters' },
-      { name: 'fno_submitted', type: 'task', index: 4, display: 'Submitted to FNO', desc: 'Order has been submitted to the appropriate FNO' },
-      { name: 'fno_accepted', type: 'gateway', index: 5, display: 'FNO Accepted', desc: 'FNO has accepted the order for processing' },
-      { name: 'installation_scheduled', type: 'task', index: 6, display: 'Installation Scheduled', desc: 'Installation has been scheduled with customer' },
-      { name: 'in_progress', type: 'task', index: 7, display: 'Installation In Progress', desc: 'Installation is currently in progress' },
-      { name: 'installed', type: 'task', index: 8, display: 'Installation Completed', desc: 'Installation has been completed successfully' },
-      { name: 'activated', type: 'task', index: 9, display: 'Service Activated', desc: 'Service has been activated for customer' },
-      { name: 'completed', type: 'end', index: 10, display: 'Order Completed', desc: 'Order has been completed successfully' },
-      { name: 'cancelled', type: 'end', index: 11, display: 'Order Cancelled', desc: 'Order has been cancelled' }
-    ];
+    if (orderType === 'new_install') {
+      desiredStates = [
+        { name: 'created', type: 'start', index: 1, display: 'Order Created', desc: 'Order has been created and is ready for processing' },
+        { name: 'validated', type: 'validation', index: 2, display: 'Order Validated', desc: 'Order data has been validated for completeness and accuracy' },
+        { name: 'enriched', type: 'enrichment', index: 3, display: 'Order Enriched', desc: 'Order has been enriched with network-specific parameters' },
+        { name: 'fno_submitted', type: 'task', index: 4, display: 'Submitted to FNO', desc: 'Order has been submitted to the appropriate FNO' },
+        { name: 'fno_accepted', type: 'gateway', index: 5, display: 'FNO Accepted', desc: 'FNO has accepted the order for processing' },
+        { name: 'installation_scheduled', type: 'task', index: 6, display: 'Installation Scheduled', desc: 'Installation has been scheduled with customer' },
+        { name: 'in_progress', type: 'task', index: 7, display: 'Installation In Progress', desc: 'Installation is currently in progress' },
+        { name: 'installed', type: 'task', index: 8, display: 'Installation Completed', desc: 'Installation has been completed successfully' },
+        { name: 'activated', type: 'task', index: 9, display: 'Service Activated', desc: 'Service has been activated for customer' },
+        { name: 'completed', type: 'end', index: 10, display: 'Order Completed', desc: 'Order has been completed successfully' },
+        { name: 'cancelled', type: 'end', index: 11, display: 'Order Cancelled', desc: 'Order has been cancelled' }
+      ];
+      transitions = [
+        { from: 'created', to: 'validated', name: 'Validate Order', isAutomatic: true },
+        { from: 'validated', to: 'enriched', name: 'Enrich Order', isAutomatic: true },
+        { from: 'enriched', to: 'fno_submitted', name: 'Submit to FNO', isAutomatic: false, conditions: { requires_fno_id: true } },
+        { from: 'fno_submitted', to: 'fno_accepted', name: 'FNO Accepts', isAutomatic: false },
+        { from: 'fno_accepted', to: 'installation_scheduled', name: 'Schedule Installation', isAutomatic: false },
+        { from: 'installation_scheduled', to: 'in_progress', name: 'Start Installation', isAutomatic: false },
+        { from: 'in_progress', to: 'installed', name: 'Complete Installation', isAutomatic: false },
+        { from: 'installed', to: 'activated', name: 'Activate Service', isAutomatic: false },
+        { from: 'activated', to: 'completed', name: 'Complete Order', isAutomatic: false },
+      ];
+    } else if (orderType === 'service_change') {
+      desiredStates = [
+        { name: 'created', type: 'start', index: 1, display: 'Order Created', desc: 'Service change order created' },
+        { name: 'validated', type: 'validation', index: 2, display: 'Order Validated', desc: 'Order validated for change' },
+        { name: 'change_scheduled', type: 'task', index: 3, display: 'Change Scheduled', desc: 'Change has been scheduled' },
+        { name: 'in_progress', type: 'task', index: 4, display: 'Change In Progress', desc: 'Service change is being applied' },
+        { name: 'changed', type: 'task', index: 5, display: 'Change Applied', desc: 'Service change applied successfully' },
+        { name: 'activated', type: 'task', index: 6, display: 'Service Re-Activated', desc: 'Service re-activated after change' },
+        { name: 'completed', type: 'end', index: 7, display: 'Order Completed', desc: 'Service change completed' },
+        { name: 'cancelled', type: 'end', index: 8, display: 'Order Cancelled', desc: 'Order has been cancelled' }
+      ];
+      transitions = [
+        { from: 'created', to: 'validated', name: 'Validate Order', isAutomatic: true },
+        { from: 'validated', to: 'change_scheduled', name: 'Schedule Change', isAutomatic: false },
+        { from: 'change_scheduled', to: 'in_progress', name: 'Start Change', isAutomatic: false },
+        { from: 'in_progress', to: 'changed', name: 'Apply Change', isAutomatic: false },
+        { from: 'changed', to: 'activated', name: 'Re-Activate Service', isAutomatic: false },
+        { from: 'activated', to: 'completed', name: 'Complete Order', isAutomatic: false },
+      ];
+    } else if (orderType === 'disconnect') {
+      desiredStates = [
+        { name: 'created', type: 'start', index: 1, display: 'Order Created', desc: 'Disconnect order created' },
+        { name: 'validated', type: 'validation', index: 2, display: 'Order Validated', desc: 'Order validated for disconnection' },
+        { name: 'disconnection_scheduled', type: 'task', index: 3, display: 'Disconnection Scheduled', desc: 'Disconnection scheduled with customer' },
+        { name: 'in_progress', type: 'task', index: 4, display: 'Disconnection In Progress', desc: 'Disconnection underway' },
+        { name: 'disconnected', type: 'task', index: 5, display: 'Disconnected', desc: 'Service disconnected' },
+        { name: 'completed', type: 'end', index: 6, display: 'Order Completed', desc: 'Disconnection completed' },
+        { name: 'cancelled', type: 'end', index: 7, display: 'Order Cancelled', desc: 'Order has been cancelled' }
+      ];
+      transitions = [
+        { from: 'created', to: 'validated', name: 'Validate Order', isAutomatic: true },
+        { from: 'validated', to: 'disconnection_scheduled', name: 'Schedule Disconnection', isAutomatic: false },
+        { from: 'disconnection_scheduled', to: 'in_progress', name: 'Start Disconnection', isAutomatic: false },
+        { from: 'in_progress', to: 'disconnected', name: 'Complete Disconnection', isAutomatic: false },
+        { from: 'disconnected', to: 'completed', name: 'Complete Order', isAutomatic: false },
+      ];
+    } else {
+      // Unknown order type: do nothing
+      return;
+    }
+
+    // Insert missing states
+    for (const s of desiredStates) {
+      if (!existingNames.has(s.name)) {
+        await this.db.query(
+          `INSERT INTO workflow_states (workflow_id, state_name, state_type, order_index, display_name, description, config, is_required, estimated_duration_hours)
+           VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+           ON CONFLICT DO NOTHING`,
+          [workflowId, s.name, s.type, s.index, s.display, s.desc, {}, s.name !== 'completed', 0]
+        );
+      }
+    }
 
     // Insert missing states
     for (const s of desiredStates) {
@@ -115,29 +181,7 @@ export class ConfigurableWorkflowService {
     );
     const nameToId = new Map<string, string>(refreshed.rows.map((r: any) => [r.state_name, r.id] as const));
 
-    // Desired transitions for new_install
-    const transitions: Array<{ from: string; to: string; name: string; isAutomatic: boolean; conditions?: any }> = [
-      { from: 'created', to: 'validated', name: 'Validate Order', isAutomatic: true },
-      { from: 'validated', to: 'enriched', name: 'Enrich Order', isAutomatic: true },
-      { from: 'enriched', to: 'fno_submitted', name: 'Submit to FNO', isAutomatic: false, conditions: { requires_fno_id: true } },
-      { from: 'fno_submitted', to: 'fno_accepted', name: 'FNO Accepts', isAutomatic: false },
-      { from: 'fno_accepted', to: 'installation_scheduled', name: 'Schedule Installation', isAutomatic: false },
-      { from: 'installation_scheduled', to: 'in_progress', name: 'Start Installation', isAutomatic: false },
-      { from: 'in_progress', to: 'installed', name: 'Complete Installation', isAutomatic: false },
-      { from: 'installed', to: 'activated', name: 'Activate Service', isAutomatic: false },
-      { from: 'activated', to: 'completed', name: 'Complete Order', isAutomatic: false },
-      // Cancellations allowed from most active states
-      { from: 'created', to: 'cancelled', name: 'Cancel Order', isAutomatic: false },
-      { from: 'validated', to: 'cancelled', name: 'Cancel Order', isAutomatic: false },
-      { from: 'enriched', to: 'cancelled', name: 'Cancel Order', isAutomatic: false },
-      { from: 'fno_submitted', to: 'cancelled', name: 'Cancel Order', isAutomatic: false },
-      { from: 'fno_accepted', to: 'cancelled', name: 'Cancel Order', isAutomatic: false },
-      { from: 'installation_scheduled', to: 'cancelled', name: 'Cancel Order', isAutomatic: false },
-      { from: 'in_progress', to: 'cancelled', name: 'Cancel Order', isAutomatic: false },
-      { from: 'installed', to: 'cancelled', name: 'Cancel Order', isAutomatic: false },
-      { from: 'activated', to: 'cancelled', name: 'Cancel Order', isAutomatic: false }
-    ];
-
+    // Add base transitions per orderType
     for (const t of transitions) {
       const fromId = nameToId.get(t.from);
       const toId = nameToId.get(t.to);
@@ -151,6 +195,25 @@ export class ConfigurableWorkflowService {
          )`,
         [workflowId, fromId, toId, t.name, t.isAutomatic, t.conditions || {}]
       );
+    }
+
+    // Add cancellation transitions from most active states where applicable
+    const cancellableFrom = ['created','validated','enriched','fno_submitted','fno_accepted','installation_scheduled','in_progress','installed','activated','change_scheduled','changed','disconnection_scheduled','disconnected'];
+    if (nameToId.has('cancelled')) {
+      const toCancelled = nameToId.get('cancelled') as string;
+      for (const from of cancellableFrom) {
+        const fromId = nameToId.get(from);
+        if (!fromId) continue;
+        await this.db.query(
+          `INSERT INTO workflow_transitions (workflow_id, from_state_id, to_state_id, transition_name, is_automatic, conditions)
+           SELECT $1, $2, $3, $4, $5, $6
+           WHERE NOT EXISTS (
+             SELECT 1 FROM workflow_transitions 
+             WHERE workflow_id = $1 AND from_state_id = $2 AND to_state_id = $3
+           )`,
+          [workflowId, fromId, toCancelled, 'Cancel Order', false, {}]
+        );
+      }
     }
   }
 
@@ -228,9 +291,20 @@ export class ConfigurableWorkflowService {
     // Ensure PRD default states/transitions exist for this workflow if missing
     await this.ensurePrdDefaults(workflow.id, orderType);
     const states = await this.getWorkflowStates(workflow.id);
-    const startState = states.find(s => s.stateType === 'start');
+    let startState = states.find(s => s.stateType === 'start');
     if (!startState) {
-      throw new Error(`No start state found for workflow: ${workflow.name}`);
+      // Safety net: seed minimal 'created' start state and retry
+      await this.db.query(
+        `INSERT INTO workflow_states (workflow_id, state_name, state_type, order_index, display_name, description, config, is_required, estimated_duration_hours)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+         ON CONFLICT DO NOTHING`,
+        [workflow.id, 'created', 'start', 1, 'Order Created', 'Auto-seeded start state', {}, true, 0]
+      );
+      const refetched = await this.getWorkflowStates(workflow.id);
+      startState = refetched.find(s => s.stateType === 'start') || null as any;
+      if (!startState) {
+        throw new Error(`No start state found for workflow: ${workflow.name}`);
+      }
     }
 
     const result = await this.db.query(
@@ -509,39 +583,51 @@ export class ConfigurableWorkflowService {
     // Update order row
     await this.db.query('UPDATE orders SET status = $1, updated_at = NOW() WHERE id = $2', [stateName, orderId]);
 
-    // Map order status to onboarding step
-    let step: string | null = null;
-    switch (String(stateName)) {
-      case 'validated':
-        step = 'initiated';
-        break;
-      case 'enriched':
-        step = 'requirements_confirmed';
-        break;
-      case 'fno_submitted':
-        step = 'provisioning_requested';
-        break;
-      case 'fno_accepted':
-        step = 'provisioning_in_flight';
-        break;
-      case 'installation_scheduled':
-        step = 'installation_scheduled';
-        break;
-      case 'installed':
-        step = 'installation_complete';
-        break;
-      case 'activated':
-        step = 'service_activated';
-        break;
-      case 'completed':
-        step = 'completed';
-        break;
-      case 'cancelled':
-        step = 'cancelled';
-        break;
-      default:
-        step = null;
-    }
+    // Fetch order_type for per-type onboarding mapping
+    const ord = await this.db.query('SELECT order_type FROM orders WHERE id = $1 LIMIT 1', [orderId]);
+    const orderType: string = (ord.rows[0]?.order_type || 'new_install') as string;
+
+    // Map order status to onboarding step per order type (PRD-aligned)
+    const mapNewInstall = (s: string): string | null => {
+      switch (s) {
+        case 'validated': return 'initiated';
+        case 'enriched': return 'requirements_confirmed';
+        case 'fno_submitted': return 'provisioning_requested';
+        case 'fno_accepted': return 'provisioning_in_flight';
+        case 'installation_scheduled': return 'installation_scheduled';
+        case 'installed': return 'installation_complete';
+        case 'activated': return 'service_activated';
+        case 'completed': return 'completed';
+        case 'cancelled': return 'cancelled';
+        default: return null;
+      }
+    };
+    const mapServiceChange = (s: string): string | null => {
+      switch (s) {
+        case 'validated': return 'initiated';
+        case 'change_scheduled': return 'service_configuration';
+        case 'in_progress': return 'provisioning_in_flight';
+        case 'changed': return 'service_activated';
+        case 'activated': return 'service_activated';
+        case 'completed': return 'completed';
+        case 'cancelled': return 'cancelled';
+        default: return null;
+      }
+    };
+    const mapDisconnect = (s: string): string | null => {
+      switch (s) {
+        case 'validated': return 'initiated';
+        case 'disconnection_scheduled': return 'service_configuration';
+        case 'in_progress': return 'provisioning_in_flight';
+        case 'disconnected': return 'installation_complete';
+        case 'completed': return 'completed';
+        case 'cancelled': return 'cancelled';
+        default: return null;
+      }
+    };
+
+    const mapper = orderType === 'service_change' ? mapServiceChange : orderType === 'disconnect' ? mapDisconnect : mapNewInstall;
+    const step = mapper(String(stateName));
     if (step === null) return;
 
     const r = await this.db.query('SELECT id, current_step FROM customer_onboarding WHERE order_id = $1 ORDER BY started_at DESC LIMIT 1', [orderId]);

--- a/src/services/orders.service.ts
+++ b/src/services/orders.service.ts
@@ -215,14 +215,14 @@ export class OrdersService {
       console.log(`[orders] Executed workflow transition for order ${orderId} to ${newStatus}`);
     } else {
       // Fallback to legacy workflow engine
-      const updatedOrder = await this.workflowEngine.transitionOrder(order, newStatus);
-      
-      // Update order in database
-      await this.db.query(
-        'UPDATE orders SET status = $1, updated_at = NOW() WHERE id = $2',
-        [newStatus, orderId]
-      );
-      
+    const updatedOrder = await this.workflowEngine.transitionOrder(order, newStatus);
+
+    // Update order in database
+    await this.db.query(
+      'UPDATE orders SET status = $1, updated_at = NOW() WHERE id = $2',
+      [newStatus, orderId]
+    );
+
       console.log(`[orders] Used legacy workflow for order ${orderId} to ${newStatus}`);
     }
 
@@ -249,7 +249,7 @@ export class OrdersService {
     if ((after as any).status === 'validated') {
       await this.ensureOnboardingForOrder(after.id, (after as any).customerId, changedBy || 'system');
     }
-    // Sync onboarding progression with order status per PRD mapping
+    // Sync onboarding progression with order status per PRD mapping and order type
     await this.syncOnboardingForOrder(after);
     return after;
   }


### PR DESCRIPTION
…ng over orders\n\n- Return 410 Gone for GET /onboarding/:id/steps and workflow state/history/transitions\n- Keep onboarding for assignment, SLA, notes, metrics; progress derived from order workflow\n- Preserve active/completed listings and completion metrics